### PR TITLE
Add a space between the labels in the default article template

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -63,7 +63,7 @@ site:: {{#siteName}}[{{{siteName}}}]{{/siteName}}({{{originalUrl}}})
 author:: {{{author}}}
 {{/author}}
 {{#labels.length}}
-labels:: {{#labels}}[[{{{name}}}]]{{/labels}}
+labels:: {{#labels}}[[{{{name}}}]] {{/labels}}
 {{/labels.length}}
 date-saved:: {{{dateSaved}}}
 {{#datePublished}}


### PR DESCRIPTION
Separate the labels with a space to make it easier to read