### PR TITLE
Add a Note Block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   LSPluginBaseInfo,
 } from '@logseq/libs/dist/LSPlugin'
 import { PageEntity } from '@logseq/libs/dist/LSPlugin.user'
-import { setup as l10nSetup, t } from 'logseq-l10n'; //https://github.com/sethyuan/logseq-l10n
+import { setup as l10nSetup, t } from 'logseq-l10n' //https://github.com/sethyuan/logseq-l10n
 import { DateTime } from 'luxon'
 import {
   Article,
@@ -409,7 +409,6 @@ const fetchOmnivore = async (inBackground = false) => {
                     highlight,
                     {
                       sibling: false,
-                      keepUUID: true,
                     }
                   )
                 }
@@ -421,7 +420,6 @@ const fetchOmnivore = async (inBackground = false) => {
                 highlightsBlock,
                 {
                   sibling: false,
-                  keepUUID: true,
                 }
               )
             }
@@ -451,7 +449,6 @@ const fetchOmnivore = async (inBackground = false) => {
         await logseq.Editor.insertBatchBlock(targetBlockId, articleBatch, {
           before: true,
           sibling: false,
-          keepUUID: true,
         })
       }
     }


### PR DESCRIPTION
The notes from Omnivore notebook are currently only available as `{{{note}}}` in the template. Given that the note can be a free-form text, there is a high probability of the note breaking the formatting.

This PR creates a `### Note` block right above the `### Highlights` and puts each line of the note into a separate child block.