### PR TITLE
Adjust the position of the note property

### DIFF
--- a/src/settings/template.ts
+++ b/src/settings/template.ts
@@ -73,9 +73,9 @@ date-saved:: {{{dateSaved}}}
 date-published:: {{{datePublished}}}
 {{/datePublished}}`
 
-export const defaultHighlightTemplate = `> {{{text}}} [⤴️]({{{highlightUrl}}}) {{#labels}} #[[{{{name}}}]] {{/labels}}
+export const defaultHighlightTemplate = `{{#note.length}}note:: {{{note}}}{{/note.length}}
 
-{{#note.length}}note:: {{{note}}}{{/note.length}}`
+> {{{text}}} [⤴️]({{{highlightUrl}}}) {{#labels}} #[[{{{name}}}]] {{/labels}}`
 
 const getItemState = (item: Item): string => {
   if (item.isArchived) {


### PR DESCRIPTION
Adjust the position of the note property in the default highlight template to solve the problem that the note is not displayed after synchronization.